### PR TITLE
6.1 edit meetings server

### DIFF
--- a/src/model/Meeting.ts
+++ b/src/model/Meeting.ts
@@ -8,6 +8,7 @@ export class Location {
 
 export class Meeting {
   id: string;
+  userMeetingId: string;
   title: string;
   location: Location;
   owner: Participant;

--- a/src/rest/meetings/meeting_functions.ts
+++ b/src/rest/meetings/meeting_functions.ts
@@ -92,7 +92,7 @@ export function updateMeeting(req: Request,
   const endMoment = moment(event.end);
   const roomId = req.params.roomEmail;
 
-  logger.info('Want to create meeting:', event);
+  logger.info('Want to update meeting:', event);
   const updateRoomMeeting = (room: Room) => {
     updateMeetingOperation(meetingService,
                            id,

--- a/src/services/meetings/CachedMeetingService.ts
+++ b/src/services/meetings/CachedMeetingService.ts
@@ -102,10 +102,17 @@ export class CachedMeetingService implements MeetingsService {
   }
 
 
-  updateMeeting(id: string, subj: string, start: Moment, duration: Duration, owner: Participant, room: Room): Promise<Meeting> {
+  updateUserMeeting(id: string, subj: string, start: Moment, duration: Duration, owner: Participant, room: Room): Promise<Meeting> {
     return this.delegatedMeetingsService
-               .updateMeeting(id, subj, start, duration, owner, room)
-               .then(meeting => this.cacheMeeting(room, meeting))
+               .updateUserMeeting(id, subj, start, duration, owner, room)
+               // refresh room cache?
+               .then(meeting => {
+                 const startOfDate = start.clone().startOf('day');
+                 const endDate = start.clone().add(duration).endOf('day');
+                 return this.refreshCache(room, startOfDate, endDate)
+                            .then(() => meeting);
+               })
+               .then(meeting => this.cacheUserMeeting(owner, meeting))
                .catch(error => {
                  logger.error(error);
                  throw new Error(error);
@@ -238,6 +245,11 @@ export class CachedMeetingService implements MeetingsService {
   }
 
 
+  private cacheUserMeeting(owner: Participant, meeting: Meeting) {
+    return this.getCacheForOwner(owner).put(meeting);
+  }
+
+
   private evictMeeting(id: string) {
     this.roomSubCaches.forEach(cache => cache.remove(id));
     this.ownerSubCaches.forEach(cache => cache.remove(id));
@@ -289,21 +301,10 @@ class PassThroughMeetingService implements MeetingsService {
 
   createMeeting(subj: string, start: moment.Moment, duration: moment.Duration, owner: Participant, room: Room): Promise<Meeting> {
     return new Promise((resolve) => {
-      const roomMeeting: Meeting = {
-        id: uuid(),
-        owner: owner,
-        title: owner.name, // simulates microsoft's behavior
-        start: start,
-        location: {displayName: room.name},
-        end: start.clone().add(duration),
-        participants: [owner, room],
-      };
-
-
-      this.meetings.push(roomMeeting);
-
+      const userMeetingId = uuid();
       const userMeeting: Meeting = {
-        id: roomMeeting.id,
+        id: userMeetingId,
+        userMeetingId: userMeetingId,
         owner: owner,
         title: subj, // simulates microsoft's behavior
         start: start,
@@ -314,12 +315,25 @@ class PassThroughMeetingService implements MeetingsService {
 
       this.userMeetings.push(userMeeting);
 
+      const roomMeeting: Meeting = {
+        id: uuid(),
+        userMeetingId: userMeeting.id,
+        owner: owner,
+        title: owner.name, // simulates microsoft's behavior
+        start: start,
+        location: {displayName: room.name},
+        end: start.clone().add(duration),
+        participants: [owner, room],
+      };
+
+      this.meetings.push(roomMeeting);
+
       resolve(roomMeeting);
     });
   }
 
 
-  updateMeeting(id: string, subj: string, start: moment.Moment, duration: moment.Duration, owner: Participant, room: Room): Promise<Meeting> {
+  updateUserMeeting(id: string, subj: string, start: moment.Moment, duration: moment.Duration, owner: Participant, room: Room): Promise<Meeting> {
     function update(meetings: Meeting[], start: moment.Moment, duration: moment.Duration, subj?: string) {
       const roomMeeting = meetings.find(meeting => meeting.id === id);
 

--- a/src/services/meetings/CachedMeetingService.ts
+++ b/src/services/meetings/CachedMeetingService.ts
@@ -66,7 +66,6 @@ export class CachedMeetingService implements MeetingsService {
 
   getUserMeetings(user: Participant, start: Moment, end: Moment): Promise<Meeting[]> {
     const userCache = this.getCacheForOwner(user);
-    console.log('CMS:getUserMeetings', userCache);
     const fetch = userCache.isCacheWithinBound(start, end) ? Promise.resolve() : this.refreshUserCache(user, start, end);
     return fetch.then(() => userCache.getMeetings(start, end));
   }
@@ -295,6 +294,7 @@ class PassThroughMeetingService implements MeetingsService {
 
   getUserMeetings(user: Participant, start: Moment, end: Moment): Promise<Meeting[]> {
     const filtered = this.userMeetings.filter(meeting => meeting.owner.email === user.email);
+    console.info('Filtered user meetings', filtered);
     return Promise.resolve(filtered);
   }
 
@@ -316,7 +316,7 @@ class PassThroughMeetingService implements MeetingsService {
       this.userMeetings.push(userMeeting);
 
       const roomMeeting: Meeting = {
-        id: uuid(),
+        id: userMeeting.id,
         userMeetingId: userMeeting.id,
         owner: owner,
         title: owner.name, // simulates microsoft's behavior
@@ -353,9 +353,9 @@ class PassThroughMeetingService implements MeetingsService {
 
     return new Promise((resolve) => {
       const roomMeeting = update(this.meetings, start, duration);
-      update(this.userMeetings, start, duration, subj);
+      const userMeeting = update(this.userMeetings, start, duration, subj);
 
-      resolve(roomMeeting);
+      resolve(userMeeting);
     });
   }
 

--- a/src/services/meetings/MSGraphMeetingService.ts
+++ b/src/services/meetings/MSGraphMeetingService.ts
@@ -62,7 +62,7 @@ export class MSGraphMeetingService extends MSGraphBase implements MeetingsServic
   }
 
 
-  updateMeeting(id: string, subj: string, start: Moment, duration: Duration, owner: Participant, room: Room): Promise<Meeting> {
+  updateUserMeeting(id: string, subj: string, start: Moment, duration: Duration, owner: Participant, room: Room): Promise<Meeting> {
     const eventData = MSGraphMeetingService._generateEventPayload(subj,
                                                                   start,
                                                                   moment.duration(1, 'minute'),
@@ -263,6 +263,7 @@ export class MSGraphMeetingService extends MSGraphBase implements MeetingsServic
 
     const mappedMeeting = {
       id: meeting.id as string,
+      userMeetingId: meeting.userMeetingId as string,
       title: meeting.subject as string,
       owner: mapToParticipant(meeting.organizer),
       location: meeting.location,

--- a/src/services/meetings/MeetingService.ts
+++ b/src/services/meetings/MeetingService.ts
@@ -19,7 +19,12 @@ export interface MeetingsService {
   createMeeting(subj: string, start: Moment, duration: Duration, owner: Participant, room: Participant): Promise<Meeting>;
 
 
-  updateMeeting(id: string, subj: string, start: Moment, duration: Duration, owner: Participant, room: Participant): Promise<Meeting>;
+  updateUserMeeting(id: string,
+                    subj: string,
+                    start: Moment,
+                    duration: Duration,
+                    owner: Participant,
+                    room: Participant): Promise<Meeting>;
 
 
   deleteMeeting(owner: Participant, id: string): Promise<any>;

--- a/src/services/meetings/MeetingsOps.ts
+++ b/src/services/meetings/MeetingsOps.ts
@@ -22,11 +22,12 @@ function hasAnyMeetingConflicts(meetings: Meeting[], newMeetingStart: moment.Mom
 
 function hasConflicts(meetings: Meeting[], originalId: string, start: Moment, end: Moment) {
   const conflict = meetings.find(meeting => {
+    logger.info(`Checking conflict: ${meeting.id} against ${originalId}`);
     return meeting.id !== originalId && isMeetingOverlapping(meeting.start, meeting.end, start, end);
   });
 
   if (conflict) {
-    throw 'Found conflict';
+    throw 'Found other meeting conflict';
   }
 }
 
@@ -72,6 +73,7 @@ export function createMeetingOperation(meetingService: MeetingsService,
 
 export function updateMeetingOperation(meetingService: MeetingsService,
                                        id: string,
+                                       userMeetingId: string,
                                        subj: string,
                                        start: Moment,
                                        duration: Duration,
@@ -81,7 +83,7 @@ export function updateMeetingOperation(meetingService: MeetingsService,
   return new Promise((resolve, reject) => {
     const ifAvailable = checkMeetingTimeIsAvailable(meetingService, room, id, start, duration);
 
-    ifAvailable.then(() => meetingService.updateMeeting(id, subj, start, duration, owner, room)
+    ifAvailable.then(() => meetingService.updateUserMeeting(userMeetingId, subj, start, duration, owner, room)
                                          .then(resolve)
                                          .catch(reject))
                .catch(reject);

--- a/src/spring.ts
+++ b/src/spring.ts
@@ -144,7 +144,7 @@ testMeetingCreate().then((meeting) => {
   const endMoment = meeting.end;
 
   const duration = moment.duration(endMoment.diff(startMoment, 'minutes'), 'minutes');
-  meetingService.updateMeeting(meeting.id,
+  meetingService.updateUserMeeting(meeting.id,
                                'new meeting',
                                meeting.start,
                                duration,

--- a/test/rest/meetings/meeting_functions.spec.ts
+++ b/test/rest/meetings/meeting_functions.spec.ts
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import * as moment from 'moment';
 import {matchMeeting} from '../../../src/rest/meetings/meeting_functions';
+import {Meeting} from '../../../src/model/Meeting';
 
 describe('Meetings matcher', function meetingsMatcherSuite() {
   const phil = {
@@ -8,37 +9,40 @@ describe('Meetings matcher', function meetingsMatcherSuite() {
     name: 'Phil',
     mail: 'willofphil@peel.com',
     email: 'willofphil@peel.com',
-  }
+  };
 
-  const start1 = moment()
-  const end1 = start1.clone().add(10, 'minutes')
+  const start1 = moment();
+  const end1 = start1.clone().add(10, 'minutes');
 
-  const start2 = moment().add(1, 'week')
-  const end2 = start2.clone().add(10, 'minutes')
+  const start2 = moment().add(1, 'week');
+  const end2 = start2.clone().add(10, 'minutes');
 
-  const meetingInTheList = {
+  const meetingInTheList: Meeting = {
     id: '1',
+    userMeetingId: '1',
     title: 'Lunchtime',
     location: { displayName: 'NYC'},
     owner: phil,
     participants: [phil],
     start: start1,
     end: end1,
-  }
+  };
 
   const meetingNotInTheList = {
     id: '2',
+    userMeetingId: '2',
     title: 'Naptime',
     location: { displayName: 'NYC'},
     owner: phil,
     participants: [phil],
     start: start2,
     end: end2,
-  }
+  };
 
   const meetingList = [
     {
       id: '3', // Different id, but same meeting! Damn you, Microsoft!
+      userMeetingId: '3',
       title: 'Cant see title, because it is obscured by MS API',
       location: { displayName: 'NYC'},
       owner: phil,
@@ -48,6 +52,7 @@ describe('Meetings matcher', function meetingsMatcherSuite() {
     },
     {
       id: '4',
+      userMeetingId: '4',
       title: 'Dumbtime',
       location: { displayName: 'NYC'},
       owner: phil,
@@ -57,6 +62,7 @@ describe('Meetings matcher', function meetingsMatcherSuite() {
     },
     {
       id: '5',
+      userMeetingId: '5',
       title: 'Flickertime',
       location: { displayName: 'NYC'},
       owner: phil,
@@ -64,7 +70,7 @@ describe('Meetings matcher', function meetingsMatcherSuite() {
       start: start1.clone().add(2, 'hour'),
       end: end1.clone().add(2.5, 'hour'),
     },
-  ]
+  ];
 
   it('finds a meeting that exists in the list, even if they have different ids and titles, because Microsuck.', function testFindExistingMeeting() {
     const result = matchMeeting(meetingInTheList, meetingList);

--- a/test/rest/server_auth.spec.ts
+++ b/test/rest/server_auth.spec.ts
@@ -68,9 +68,6 @@ describe('tests authentication', () => {
                          return details.token;
                        })
                        .then(token => {
-                         console.log('========================================');
-                         console.log(token);
-                         console.log('========================================');
                          return request(app).get('/backdoor')
                                             .set('x-access-token', token)
                                             .expect(200)

--- a/test/rest/server_meeting.spec.ts
+++ b/test/rest/server_meeting.spec.ts
@@ -101,7 +101,7 @@ describe('meeting routes operations', function testMeetingRoutes() {
                        });
   });
 
-  it('updates an existing meeting', function testUpdateMeeting() {
+  it.only('updates an existing meeting', function testUpdateMeeting() {
     const meetingStart = '2013-05-08 10:00:00';
     const meetingEnd = '2013-05-08 10:45:00';
 
@@ -128,12 +128,13 @@ describe('meeting routes operations', function testMeetingRoutes() {
                            console.log('Original', created);
                            const updatedMeeting: MeetingRequest = {
                              id: created.id,
+                             userMeetingId: created.id,
                              title: 'this is new',
                              start: meetingStart,
                              end: meetingEnd,
                            };
 
-                           return request(app).put(`/room/${room.email}/meeting`)
+                           return request(app).put(`/room/${room.email}/meeting/${updatedMeeting.id}`)
                                               .set('Content-Type', 'application/json')
                                               .set('x-access-token', token)
                                               .send(updatedMeeting)
@@ -144,7 +145,8 @@ describe('meeting routes operations', function testMeetingRoutes() {
                                                                                        'Expected to find at least one meeting');
 
                                                 const meeting = meetings[0];
-                                                expect(meeting.title).to.be.deep.eq(updatedMeeting.title);
+                                                console.log(meeting);
+                                                expect(meeting.title).to.be.eq(updatedMeeting.title);
 
                                                 meetingService.clearCaches();
                                               });

--- a/test/services/StatefulMeeting-spec.ts
+++ b/test/services/StatefulMeeting-spec.ts
@@ -22,8 +22,6 @@ export function StatefulMeetingSpec(meetingService: MeetingsService, description
   const bruceParticipant = new Participant(BRUCE_ID);
   const redRoom = new Room('1', 'Red', redRoomId);
 
-  console.log('participants are:', bruceParticipant, redRoom);
-
   /* why do we have these three? */
   const meetingOps = new MeetingsOps(meetingService);
 

--- a/test/services/meetings/DateCachingStrategy.spec.ts
+++ b/test/services/meetings/DateCachingStrategy.spec.ts
@@ -20,6 +20,7 @@ describe('date caching suite', function startDateCachingSuite() {
 
   const first: Meeting = {
     id: '1',
+    userMeetingId: '1',
     title: 'My first meeting',
     owner: andrew,
     location: blueRoom,
@@ -30,6 +31,7 @@ describe('date caching suite', function startDateCachingSuite() {
 
   const second: Meeting = {
     id: '2',
+    userMeetingId: '2',
     title: 'My second meeting',
     owner: alex,
     location: redRoom,
@@ -40,6 +42,7 @@ describe('date caching suite', function startDateCachingSuite() {
 
   const third: Meeting = {
     id: '3',
+    userMeetingId: '3',
     title: 'My third meeting',
     owner: paul,
     location: blueRoom,
@@ -50,6 +53,7 @@ describe('date caching suite', function startDateCachingSuite() {
 
   const fourth: Meeting = {
     id: '4',
+    userMeetingId: '4',
     title: 'My fourth meeting',
     owner: alex,
     location: blueRoom,

--- a/test/services/meetings/IdCachingStrategy.spec.ts
+++ b/test/services/meetings/IdCachingStrategy.spec.ts
@@ -14,6 +14,7 @@ const redRoom = {displayName: 'Red'};
 
 const first: Meeting = {
   id: '1',
+  userMeetingId: '1',
   title: 'My first meeting',
   owner: andrew,
   location: redRoom,
@@ -24,6 +25,7 @@ const first: Meeting = {
 
 const second: Meeting = {
   id: '2',
+  userMeetingId: '2',
   title: 'My second meeting',
   owner: andrew,
   location: redRoom,
@@ -34,6 +36,7 @@ const second: Meeting = {
 
 const third: Meeting = {
   id: '3',
+  userMeetingId: '3',
   title: 'My third meeting',
   owner: karsten,
   location: redRoom,

--- a/test/services/meetings/MeetingOps.spec.ts
+++ b/test/services/meetings/MeetingOps.spec.ts
@@ -23,6 +23,7 @@ const karsten = new Participant('karsten@wipro.com');
 
 const first: Meeting = {
   id: '1',
+  userMeetingId: '1',
   title: 'My first meeting',
   owner: andrew,
   location: redRoom,
@@ -33,6 +34,7 @@ const first: Meeting = {
 
 const second: Meeting = {
   id: '2',
+  userMeetingId: '2',
   title: 'My second meeting',
   owner: andrew,
   location: redRoom,
@@ -43,6 +45,7 @@ const second: Meeting = {
 
 const third: Meeting = {
   id: '3',
+  userMeetingId: '3',
   title: 'My third meeting',
   owner: karsten,
   location: redRoom,

--- a/test/services/meetings/OwnerCachingStrategy.spec.ts
+++ b/test/services/meetings/OwnerCachingStrategy.spec.ts
@@ -26,6 +26,7 @@ const redRoom = {displayName: 'Red'};
 
 const andrewFirst: Meeting = {
   id: '1',
+  userMeetingId: '1',
   title: 'My first meeting',
   owner: andrew,
   location: redRoom,
@@ -36,6 +37,7 @@ const andrewFirst: Meeting = {
 
 const alexFirst: Meeting = {
   id: '2',
+  userMeetingId: '2',
   title: 'My second meeting',
   owner: alex,
   location: redRoom,
@@ -46,6 +48,7 @@ const alexFirst: Meeting = {
 
 const paulFirst: Meeting = {
   id: '3',
+  userMeetingId: '3',
   title: 'My third meeting',
   owner: paul,
   location: redRoom,
@@ -56,6 +59,7 @@ const paulFirst: Meeting = {
 
 const alexSecond: Meeting = {
   id: '4',
+  userMeetingId: '2',
   title: 'My fourth meeting',
   owner: alex,
   location: redRoom,

--- a/test/services/meetings/ParticipantCachingStrategy.spec.ts
+++ b/test/services/meetings/ParticipantCachingStrategy.spec.ts
@@ -16,6 +16,7 @@ const redRoom = {displayName: 'Red'};
 
 const first: Meeting = {
   id: '1',
+  userMeetingId: '1',
   title: 'My first meeting',
   owner: andrew,
   location: redRoom,
@@ -26,6 +27,7 @@ const first: Meeting = {
 
 const second: Meeting = {
   id: '2',
+  userMeetingId: '2',
   title: 'My second meeting',
   owner: alex,
   location: redRoom,
@@ -36,6 +38,7 @@ const second: Meeting = {
 
 const third: Meeting = {
   id: '3',
+  userMeetingId: '3',
   title: 'My third meeting',
   owner: paul,
   location: redRoom,
@@ -46,6 +49,7 @@ const third: Meeting = {
 
 const fourth: Meeting = {
   id: '4',
+  userMeetingId: '4',
   title: 'My fourth meeting',
   owner: alex,
   location: redRoom,
@@ -56,6 +60,7 @@ const fourth: Meeting = {
 
 const fifth: Meeting = {
   id: '5',
+  userMeetingId: '5',
   title: 'Owner as participant',
   owner: zac,
   location: redRoom,

--- a/test/services/meetings/RoomCachingStrategy.spec.ts
+++ b/test/services/meetings/RoomCachingStrategy.spec.ts
@@ -15,6 +15,7 @@ const blueRoom = {displayName: 'Blue'};
 
 const first: Meeting = {
   id: '1',
+  userMeetingId: '1',
   title: 'My first meeting',
   owner: andrew,
   location: blueRoom,
@@ -25,6 +26,7 @@ const first: Meeting = {
 
 const second: Meeting = {
   id: '2',
+  userMeetingId: '2',
   title: 'My second meeting',
   owner: alex,
   location: redRoom,
@@ -35,6 +37,7 @@ const second: Meeting = {
 
 const third: Meeting = {
   id: '3',
+  userMeetingId: '3',
   title: 'My third meeting',
   owner: paul,
   location: blueRoom,
@@ -45,6 +48,7 @@ const third: Meeting = {
 
 const fourth: Meeting = {
   id: '4',
+  userMeetingId: '4',
   title: 'My fourth meeting',
   owner: alex,
   location: blueRoom,


### PR DESCRIPTION
This is an addendum to the 6-edit-meeting-branch in light of discoveries relevant to microsoft idiosyncracies.  We now need to maintain the concept of an id and a user perspective id.  We need to filter by all meetings when checking overlaps.  But we need to use the user id against the user cache.