### PR TITLE
Bug fix on edit time

### DIFF
--- a/src/services/meetings/MSGraphMeetingService.ts
+++ b/src/services/meetings/MSGraphMeetingService.ts
@@ -65,7 +65,7 @@ export class MSGraphMeetingService extends MSGraphBase implements MeetingsServic
   updateUserMeeting(id: string, subj: string, start: Moment, duration: Duration, owner: Participant, room: Room): Promise<Meeting> {
     const eventData = MSGraphMeetingService._generateEventPayload(subj,
                                                                   start,
-                                                                  moment.duration(1, 'minute'),
+                                                                  duration,
                                                                   owner,
                                                                   room,
                                                                   id);
@@ -272,7 +272,7 @@ export class MSGraphMeetingService extends MSGraphBase implements MeetingsServic
       end: moment.utc(meeting.end.dateTime)
     };
 
-    // logger.debug('MSGraphMeetingService::mapMeeting', mappedMeeting);
+    logger.info('MSGraphMeetingService::mapMeeting', mappedMeeting);
     return mappedMeeting;
   }
 }


### PR DESCRIPTION
  Stop making meetings one minute long when we edit them