### PR TITLE
List users: Add internal users service 

### DIFF
--- a/src/config/identities/index.ts
+++ b/src/config/identities/index.ts
@@ -9,6 +9,8 @@ export interface Identity {
   domain: Domain;
   credentials?: GraphAPIParameters;
   serviceUserEmail?: string;
+  internalTeam?: string;
+  externalTeam?: string;
 }
 
 export const roman: Identity = {
@@ -20,6 +22,8 @@ export const buildit: Identity = {
   domain: builditDomain,
   credentials: builditCreds,
   serviceUserEmail: 'roodmin@builditcontoso.onmicrosoft.com',
+  internalTeam: 'DESIGNIT',
+  externalTeam: 'WIPRO',
 };
 
 export const test: Identity = {

--- a/src/config/identity.ts
+++ b/src/config/identity.ts
@@ -53,3 +53,14 @@ export function getServiceUser(env: string) {
     }
   }
 }
+
+export function getExternalTeam(env: string) {
+  switch (env) {
+    case 'buildit': {
+      return buildit.externalTeam;
+    }
+    default: {
+      throw new Error(`No external team is defined for this environment: ${env}`);
+    }
+  }
+}

--- a/src/config/identity.ts
+++ b/src/config/identity.ts
@@ -64,3 +64,14 @@ export function getExternalTeam(env: string) {
     }
   }
 }
+
+export function getInternalTeam(env: string) {
+  switch (env) {
+    case 'buildit': {
+      return buildit.internalTeam;
+    }
+    default: {
+      throw new Error(`No internal team is defined for this environment: ${env}`);
+    }
+  }
+}

--- a/src/rest/user_routes.ts
+++ b/src/rest/user_routes.ts
@@ -11,10 +11,12 @@ export function configureUsersRoutes(app: Express,
                                      mailSvc: MailService): Express {
 
   app.get('/users', (req, res) => {
-    // Currently we are only returning the external (i.e. Wipro) users
-    // Will need to also return the internal (i.e. Designit) users
-    userSvc.listExternalUsers()
-      .then(users => {
+    Promise.all([
+      userSvc.listInternalUsers(),
+      userSvc.listExternalUsers()
+    ])
+      .then(userLists => {
+        const users = userLists[0].concat(userLists[1])
         res.json(users);
       })
       .catch(err => {

--- a/src/services/users/MSGraphUserService.ts
+++ b/src/services/users/MSGraphUserService.ts
@@ -21,7 +21,7 @@ export class MSGraphUserService extends MSGraphBase implements UserService {
                .get() as Promise<any>;
   }
 
-  listExternalUsers(): Promise<Array<MSUser>> {
+  listExternalUsers(): Promise<Array<BookitUser>> {
     // return Promise.reject('in ms user service')
     const bookitServiceUserId = getServiceUser('buildit');
 
@@ -37,8 +37,14 @@ export class MSGraphUserService extends MSGraphBase implements UserService {
                        reject(error);
                        return;
                      }
-                     const users = response.body;
-                     resolve(users);
+                     const users = response.body.value;
+                     const mapUser = (user: any) => ({
+                       email: user.emailAddresses[0].address,
+                       team: 'WIPRO', 
+                       roles: user.categories,
+                       createdDateTime: user.createdDateTime,
+                     })
+                     resolve(users.map(mapUser));
                    });
           });
     });

--- a/src/services/users/MSGraphUserService.ts
+++ b/src/services/users/MSGraphUserService.ts
@@ -5,7 +5,7 @@ import {MSGraphBase} from '../MSGraphBase';
 import {MSUser, UserService} from './UserService';
 import {GraphTokenProvider} from '../tokens/TokenProviders';
 import {BookitUser} from '../../model/BookitUser';
-import {getServiceUser} from '../../config/identity';
+import {getServiceUser, getExternalTeam} from '../../config/identity';
 
 export class MSGraphUserService extends MSGraphBase implements UserService {
 
@@ -21,9 +21,9 @@ export class MSGraphUserService extends MSGraphBase implements UserService {
                .get() as Promise<any>;
   }
 
-  listExternalUsers(): Promise<Array<BookitUser>> {
-    // return Promise.reject('in ms user service')
+  listExternalUsers(): Promise<Array<any>> {
     const bookitServiceUserId = getServiceUser('buildit');
+    const externalTeam = getExternalTeam('buildit');
 
     return new Promise((resolve, reject) => {
       const URL = `https://graph.microsoft.com/v1.0/users/${bookitServiceUserId}/contacts`;
@@ -40,7 +40,7 @@ export class MSGraphUserService extends MSGraphBase implements UserService {
                      const users = response.body.value;
                      const mapUser = (user: any) => ({
                        email: user.emailAddresses[0].address,
-                       team: 'WIPRO', 
+                       team: externalTeam,
                        roles: user.categories,
                        createdDateTime: user.createdDateTime,
                      })

--- a/src/services/users/MSGraphUserService.ts
+++ b/src/services/users/MSGraphUserService.ts
@@ -5,7 +5,7 @@ import {MSGraphBase} from '../MSGraphBase';
 import {MSUser, UserService} from './UserService';
 import {GraphTokenProvider} from '../tokens/TokenProviders';
 import {BookitUser} from '../../model/BookitUser';
-import {getServiceUser, getExternalTeam} from '../../config/identity';
+import {getServiceUser, getExternalTeam, getInternalTeam} from '../../config/identity';
 
 export class MSGraphUserService extends MSGraphBase implements UserService {
 
@@ -19,6 +19,43 @@ export class MSGraphUserService extends MSGraphBase implements UserService {
                .api(`/users/${userId}/ownedDevices`)
                // .select('id,displayName,mail')
                .get() as Promise<any>;
+  }
+
+  listInternalUsers(): Promise<Array<any>> {
+    const bookitServiceUserId = getServiceUser('buildit');
+    const internalTeam = getInternalTeam('buildit');
+
+    return new Promise((resolve, reject) => {
+      const URL = `https://graph.microsoft.com/v1.0/users/`;
+      logger.info('GET', URL);
+      this.tokenOperations.withToken()
+          .then(token => {
+            request.get(URL)
+                   .set('Authorization', `Bearer ${token}`)
+                   .end((error, response) => {
+                     if (error) {
+                       reject(error);
+                       return;
+                     }
+                     const users = response.body.value;
+                     const mapUser = (user: any) => ({
+                       email: user.userPrincipalName,
+                       team: internalTeam,
+                       roles: [''], // How to get this in the context of a "user"?
+                       createdDateTime: '',
+                       firstName: user.givenName,
+                       lastName: user.surname,
+                     })
+                     const filterOutRooms = (user: any) => !(user.email.search('-room') > -1)
+                     resolve(
+                       users
+                        .map(mapUser)
+                        .filter(filterOutRooms)
+                     );
+                   });
+          });
+    });
+
   }
 
   listExternalUsers(): Promise<Array<any>> {
@@ -43,6 +80,8 @@ export class MSGraphUserService extends MSGraphBase implements UserService {
                        team: externalTeam,
                        roles: user.categories,
                        createdDateTime: user.createdDateTime,
+                       firstName: '',
+                       lastName: '',
                      })
                      resolve(users.map(mapUser));
                    });

--- a/src/services/users/MockUserService.ts
+++ b/src/services/users/MockUserService.ts
@@ -1,6 +1,6 @@
 import {RootLog as logger} from '../../utils/RootLogger';
 
-import {MSUser, UserService} from './UserService';
+import {UserService} from './UserService';
 import {BookitUser} from '../../model/BookitUser';
 
 export class MockUserService implements UserService {
@@ -9,7 +9,7 @@ export class MockUserService implements UserService {
   }
 
 
-  listExternalUsers(): Promise<Array<MSUser>> {
+  listExternalUsers(): Promise<Array<BookitUser>> {
     return new Promise((resolve) => {
       throw 'Implement me';
     });

--- a/src/services/users/MockUserService.ts
+++ b/src/services/users/MockUserService.ts
@@ -8,13 +8,17 @@ export class MockUserService implements UserService {
     logger.info('MockRoomService: initializing');
   }
 
-
   listExternalUsers(): Promise<Array<BookitUser>> {
     return new Promise((resolve) => {
       throw 'Implement me';
     });
   }
 
+  listInternalUsers(): Promise<Array<BookitUser>> {
+    return new Promise((resolve) => {
+      throw 'Implement me';
+    });
+  }
 
   getDevices(userId: string): Promise<Array<any>> {
     return Promise.reject('Unimplemented: MockUserService:getDevices');

--- a/src/services/users/UserService.ts
+++ b/src/services/users/UserService.ts
@@ -21,6 +21,8 @@ export class MSUser {
 export interface UserService {
   listExternalUsers(): Promise<Array<BookitUser>>;
 
+  listInternalUsers(): Promise<Array<BookitUser>>;
+
   getDevices(userId: string): Promise<Array<any>>;
 
   postUser(user: BookitUser): Promise<MSUser>;

--- a/src/services/users/UserService.ts
+++ b/src/services/users/UserService.ts
@@ -19,7 +19,7 @@ export class MSUser {
 }
 
 export interface UserService {
-  listExternalUsers(): Promise<Array<MSUser>>;
+  listExternalUsers(): Promise<Array<BookitUser>>;
 
   getDevices(userId: string): Promise<Array<any>>;
 

--- a/src/spring.ts
+++ b/src/spring.ts
@@ -130,4 +130,11 @@ function testListExternalUsers() {
     .catch(err => console.log(err));
 }
 
-testListExternalUsers();
+function testListInternalUsers() {
+  console.log('======================');
+  userService.listInternalUsers()
+    .then(users => console.log(users))
+    .catch(err => console.log(err));
+}
+
+testListInternalUsers();

--- a/src/utils/RootLogger.ts
+++ b/src/utils/RootLogger.ts
@@ -11,5 +11,5 @@ export const RootLog = log4js.getLogger();
 //                    },
 //                  });
 
-// RootLog.setLevel(log4js.levels.WARN);
-RootLog.setLevel(log4js.levels.INFO);
+RootLog.setLevel(log4js.levels.WARN);
+// RootLog.setLevel(log4js.levels.INFO);


### PR DESCRIPTION
Addresses a few points in [the list users ticket](https://kanbanflow.com/t/096fa42b062dbc8c82febb2a0c3f3707/3-as-an-admin-i-want-to-list-users-m).

- Add service for fetching internal users
- Formats the user object to Bookit-web's liking
- Normalizes across internal and external users