### PR TITLE
61 meeting disappears

### DIFF
--- a/src/rest/meetings/meeting_functions.ts
+++ b/src/rest/meetings/meeting_functions.ts
@@ -18,6 +18,7 @@ import {Meeting} from '../../model/Meeting';
 import {Moment} from 'moment';
 import {RoomCachingStrategy} from '../../services/meetings/RoomCachingStrategy';
 import {ListCache} from '../../utils/cache/caches';
+import {v4 as uuid} from 'uuid';
 
 
 
@@ -142,11 +143,13 @@ function getMergedRoomListUserMeetings(meetingService: MeetingsService,
                                      end: moment.Moment,
                                      userMeetings: Meeting[]): Promise<RoomMeetings[]> {
 
-  const mergedMeetings = roomList.rooms.map(room => getRoomAndMergeUserMeetings(meetingService,
-                                                                                room,
-                                                                                start,
-                                                                                end,
-                                                                                userMeetings));
+  const mergeRoom = (room: Room) => getRoomAndMergeUserMeetings(meetingService,
+                                                                room,
+                                                                start,
+                                                                end,
+                                                                userMeetings);
+
+  const mergedMeetings = roomList.rooms.map(room => mergeRoom(room));
   return Promise.all(mergedMeetings);
 }
 
@@ -205,7 +208,7 @@ export function obscureMeetingDetails(meeting: Meeting) {
 
 export function obscureMeetingIdentifier(meeting: Meeting) {
   const toReturn = Object.assign({}, meeting);
-  toReturn.id = undefined;
+  toReturn.id = 'obscured' + uuid();
 
   return toReturn;
 }

--- a/src/rest/meetings/meeting_functions.ts
+++ b/src/rest/meetings/meeting_functions.ts
@@ -252,12 +252,9 @@ function reconcileRoomCache(meeting: Meeting, roomCache: ListCache<Meeting>, roo
     return toReturn;
   }
 
-  // logger.info('Meetings for room', meetingsForRoom);
   roomCache.remove(userMeeting);
   assignProperties(toReturn, userMeeting);
 
-  const meetingsForRoomAfter = roomCache.get(roomId);
-  // logger.info('Meetings for room after', meetingsForRoomAfter);
   return toReturn;
 }
 

--- a/test/NockManager.ts
+++ b/test/NockManager.ts
@@ -22,23 +22,23 @@ export class NockManager {
 
 }
 
-const contactsListMock = { "value": [
+const contactsListMock = { 'value': [
     {
-      "@odata.etag": <any>"W/EQAAABYAAABKB99Tm01+Q6waLYtxfsHMAAAEgnPn",
-      id: <any>"AAMkAGMzMzk0MmRlLWI5Y2EtNGExOS04M2Y1LTQyNDQ4YTFjYmRhYgBGAAAAAABWLwsofOohSqdSMFArzj98BwBKB99Tm01_Q6waLYtxfsHMAAAAAAEOAABKB99Tm01_Q6waLYtxfsHMAAAEgeO2AAA=",
-      createdDateTime: <any>"2017-07-31T18:04:13Z",
-      lastModifiedDateTime: <any>"2017-07-31T18:04:14Z",
-      changeKey: <any>"EQAAABYAAABKB99Tm01+Q6waLYtxfsHMAAAEgnPn",
+      '@odata.etag': <any>'W/EQAAABYAAABKB99Tm01+Q6waLYtxfsHMAAAEgnPn',
+      id: <any>'AAMkAGMzMzk0MmRlLWI5Y2EtNGExOS04M2Y1LTQyNDQ4YTFjYmRhYgBGAAAAAABWLwsofOohSqdSMFArzj98BwBKB99Tm01_Q6waLYtxfsHMAAAAAAEOAABKB99Tm01_Q6waLYtxfsHMAAAEgeO2AAA=',
+      createdDateTime: <any>'2017-07-31T18:04:13Z',
+      lastModifiedDateTime: <any>'2017-07-31T18:04:14Z',
+      changeKey: <any>'EQAAABYAAABKB99Tm01+Q6waLYtxfsHMAAAEgnPn',
       categories: <any>[],
-      parentFolderId: <any>"AAMkAGMzMzk0MmRlLWI5Y2EtNGExOS04M2Y1LTQyNDQ4YTFjYmRhYgAuAAAAAABWLwsofOohSqdSMFArzj98AQBKB99Tm01_Q6waLYtxfsHMAAAAAAEOAAA=",
+      parentFolderId: <any>'AAMkAGMzMzk0MmRlLWI5Y2EtNGExOS04M2Y1LTQyNDQ4YTFjYmRhYgAuAAAAAABWLwsofOohSqdSMFArzj98AQBKB99Tm01_Q6waLYtxfsHMAAAAAAEOAAA=',
       birthday: <any>null,
-      fileAs: <any>"Springsteen, Bruce",
-      displayName: <any>"Bruce Springsteen",
-      givenName: <any>"Bruce",
+      fileAs: <any>'Springsteen, Bruce',
+      displayName: <any>'Bruce Springsteen',
+      givenName: <any>'Bruce',
       initials: <any>null,
       middleName: <any>null,
       nickName: <any>null,
-      surname: <any>"Springsteen",
+      surname: <any>'Springsteen',
       title: <any>null,
       yomiGivenName: <any>null,
       yomiSurname: <any>null,
@@ -57,9 +57,9 @@ const contactsListMock = { "value": [
       mobilePhone: <any>null,
       businessPhones: <any>[],
       spouseName: <any>null,
-      personalNotes: <any>"",
+      personalNotes: <any>'',
       children: <any>[],
-      emailAddresses: <any>[{"name":"bruce@builditcontoso.onmicrosoft.com","address":"bruce@builditcontoso.onmicrosoft.com"}],
+      emailAddresses: <any>[{'name': 'bruce@builditcontoso.onmicrosoft.com', 'address': 'bruce@builditcontoso.onmicrosoft.com'}],
       homeAddress: <any>{},
       businessAddress: <any>{},
       otherAddress: <any>{}

--- a/test/rest/server_meeting_create.spec.ts
+++ b/test/rest/server_meeting_create.spec.ts
@@ -1,0 +1,134 @@
+import * as moment from 'moment';
+import * as chai from 'chai';
+import * as chai_as_promised from 'chai-as-promised';
+
+const expect = chai.expect;
+chai.use(chai_as_promised);
+chai.should();
+
+import * as express from 'express';
+import * as request from 'supertest';
+
+import {RootLog as logger} from '../../src/utils/RootLogger';
+import {configureRoutes} from '../../src/rest/server';
+
+import {MeetingRequest} from '../../src/rest/meetings/meeting_routes';
+import {Meeting} from '../../src/model/Meeting';
+
+import {Runtime} from '../../src/config/runtime/configuration';
+import {generateMSRoomResource, generateMSUserResource} from '../../src/config/bootstrap/rooms';
+import {RoomMeetings} from '../../src/services/meetings/MeetingsOps';
+import {retryUntil} from '../../src/utils/retry';
+
+const roomService = Runtime.roomService;
+const meetingService = Runtime.meetingService;
+const jwtTokenProvider = Runtime.jwtTokenProvider;
+
+
+const app = configureRoutes(express(),
+                            Runtime.passwordStore,
+                            jwtTokenProvider,
+                            Runtime.roomService,
+                            Runtime.userService,
+                            Runtime.mailService,
+                            meetingService);
+
+
+const bruceOwner = generateMSUserResource('bruce', Runtime.meetingService.domain());
+const whiteRoom = generateMSRoomResource('white', Runtime.meetingService.domain());
+
+const bruceCredentials = {
+  user: bruceOwner.email,
+  password: 'who da boss?'
+};
+
+
+describe('meeting routes operations', function testMeetingRoutes() {
+
+
+  it('creates the meeting', function testCreateMeeting() {
+    const meetingStart = '2013-02-08 10:00:00';
+    const meetingEnd = '2013-02-08 10:45:00';
+
+    const meetingReq: MeetingRequest = {
+      title: 'meeting 0',
+      start: meetingStart,
+      end: meetingEnd,
+    };
+
+    const searchStart = moment(meetingStart).subtract(5, 'minutes');
+    const searchEnd = moment(meetingEnd).add(5, 'minutes');
+
+    const expected = {
+      title: bruceOwner.name,
+      start: moment(meetingReq.start),
+      duration: moment.duration(moment(meetingReq.end).diff(moment(meetingReq.start), 'minutes'), 'minutes'),
+      bruceOwner,
+      whiteRoom
+    };
+
+    const token = jwtTokenProvider.provideToken(bruceCredentials);
+
+    return request(app).post(`/room/${whiteRoom.email}/meeting`)
+                       .set('Content-Type', 'application/json')
+                       .set('x-access-token', token)
+                       .send(meetingReq)
+                       .expect(200)
+                       .then(() => meetingService.getMeetings(whiteRoom, searchStart, searchEnd))
+                       .then((meetings) => {
+                         meetingService.clearCaches();
+
+                         expect(meetings.length).to.be.at.least(1, 'Expected to find at least one meeting');
+                         const meeting = meetings[0];
+                         return expect(meeting.title).to.be.deep.eq(expected.title);
+                       });
+  });
+
+
+  it('validates parameters against the API properly', function testEndpointValidation() {
+    const validationCases = [
+      {
+        message: 'End date must be after start date',
+        data: {
+          title: 'meeting 0',
+          start: '2013-02-08 09:00:00',
+          end: '2013-02-08 08:00:00',
+        }
+      },
+      {
+        message: 'Title must be provided',
+        data: {
+          title: '',
+          start: '2013-02-08 08:00:00',
+          end: '2013-02-08 09:00:00'
+        }
+      },
+      {
+        message: 'Start date must be provided',
+        data: {
+          title: 'baaad meeting',
+          start: 'baad date',
+          end: '2013-02-08 09:00:00'
+        }
+      },
+    ];
+
+    validationCases.forEach(c => {
+      it(`Create room validations ${c.message}`, () => {
+        const meetingReq: MeetingRequest = c.data;
+
+        return request(app).post('/room/white-room@designit.com@somewhere/meeting')
+                           .set('Content-Type', 'application/json')
+                           .send(meetingReq)
+                           .expect(400)
+                           .then((res) => {
+                             expect(JSON.parse(res.text).message).to.be.eq(c.message);
+                           });
+      });
+    });
+  });
+
+
+});
+
+

--- a/test/rest/server_meeting_query.spec.ts
+++ b/test/rest/server_meeting_query.spec.ts
@@ -162,7 +162,10 @@ describe('meeting routes operations', function testMeetingRoutes() {
                          });
   });
 
-  it('has expected meetings from varying perspectives', function testExpectedNumberOfMeetings() {
+  it('exposes ids and titles for meetings owned by user and obscures these properties for meetings owned by others.', function testMeetingPropertyVisibility() {
+    // This tests for the behavior specified in the below ticket.
+    // https://kanbanflow.com/t/e5f15264f6292a2cf7f7a213e0953e6f/ep-20170622-as-a-user-i-expect-visibil
+
     const searchStart = '2013-02-08 08:00:00';
     const searchEnd = '2013-02-08 18:00:00';
 
@@ -215,17 +218,22 @@ describe('meeting routes operations', function testMeetingRoutes() {
             return acc;
           }, []);
 
-          expect(allMeetings.length).to.be.equal(2);
-
           const brucesMeetings = allMeetings.filter(m => m.owner.email === bruceOwner.email);
           const bruceMeeting = brucesMeetings[0];
-          expect(bruceMeeting.title).to.be.equal('bruces meeting');
-
-
           const otherMeetings = allMeetings.filter(m => m.owner.email !== bruceOwner.email);
           const otherMeeting = otherMeetings[0];
+
+          expect(allMeetings.length).to.be.equal(2);
+
+          // Titles of meetings owned by the user are exposed. Titles of other meetings are obscured.
+          expect(bruceMeeting.title).to.be.equal('bruces meeting');
+          expect(otherMeeting.title).to.be.equal('babs');
+
+          // Ids of meetings owned by user are exposed. Ids of other meetings are obscured.
+          expect(bruceMeeting.id).to.be.have.string('user');
           expect(otherMeeting.id).to.have.string('obscured');
-          return  expect(otherMeeting.title).to.be.equal('babs');
+
+          return;
         });
     });
 
@@ -242,26 +250,29 @@ describe('meeting routes operations', function testMeetingRoutes() {
             return acc;
           }, []);
 
-          expect(allMeetings.length).to.be.equal(2);
-
           const babsMeetings = allMeetings.filter(m => m.owner.email === babsOwner.email);
           const babsMeeting = babsMeetings[0];
-          expect(babsMeeting.title).to.be.equal('babs meeting');
-
           const otherMeetings = allMeetings.filter(m => m.owner.email !== babsOwner.email);
           const otherMeeting = otherMeetings[0];
+
+          expect(allMeetings.length).to.be.equal(2);
+
+          // Titles of meetings owned by the user are exposed. Titles of other meetings are obscured.
+          expect(babsMeeting.title).to.be.equal('babs meeting');
+          expect(otherMeeting.title).to.be.equal('bruce');
+
+          // Ids of meetings owned by user are exposed. Ids of other meetings are obscured.
+          expect(babsMeeting.id).to.be.have.string('user');
           expect(otherMeeting.id).to.have.string('obscured');
-          return expect(otherMeeting.title).to.be.equal('bruce');
+
+          return;
         });
     });
 
     return Promise.all([bruceQuery, babsQuery])
                   .then(queries => {
-
                     meetingService.clearCaches();
                   });
   });
 
 });
-
-

--- a/test/rest/server_meeting_query.spec.ts
+++ b/test/rest/server_meeting_query.spec.ts
@@ -18,12 +18,11 @@ import {Meeting} from '../../src/model/Meeting';
 import {Runtime} from '../../src/config/runtime/configuration';
 import {generateMSRoomResource, generateMSUserResource} from '../../src/config/bootstrap/rooms';
 import {RoomMeetings} from '../../src/services/meetings/MeetingsOps';
-import {retryUntil} from "../../src/utils/retry";
+
 
 const roomService = Runtime.roomService;
 const meetingService = Runtime.meetingService;
 const jwtTokenProvider = Runtime.jwtTokenProvider;
-
 
 const app = configureRoutes(express(),
                             Runtime.passwordStore,
@@ -35,13 +34,20 @@ const app = configureRoutes(express(),
 
 
 const bruceOwner = generateMSUserResource('bruce', Runtime.meetingService.domain());
+const babsOwner = generateMSUserResource('babs', Runtime.meetingService.domain());
 const whiteRoom = generateMSRoomResource('white', Runtime.meetingService.domain());
+const redRoom = generateMSRoomResource('red', Runtime.meetingService.domain());
 
 const bruceCredentials = {
   user: bruceOwner.email,
   password: 'who da boss?'
 };
 
+
+const babsCredentials = {
+  user: babsOwner.email,
+  password: 'the effect'
+};
 
 describe('meeting routes operations', function testMeetingRoutes() {
 
@@ -59,45 +65,6 @@ describe('meeting routes operations', function testMeetingRoutes() {
                                              logger.error(error);
                                              throw new Error('RLIA Should not be here');
                                            });
-                       });
-  });
-
-
-  it('creates the meeting', function testCreateMeeting() {
-    const meetingStart = '2013-02-08 10:00:00';
-    const meetingEnd = '2013-02-08 10:45:00';
-
-    const meetingReq: MeetingRequest = {
-      title: 'meeting 0',
-      start: meetingStart,
-      end: meetingEnd,
-    };
-
-    const searchStart = moment(meetingStart).subtract(5, 'minutes');
-    const searchEnd = moment(meetingEnd).add(5, 'minutes');
-
-    const expected = {
-      title: bruceOwner.name,
-      start: moment(meetingReq.start),
-      duration: moment.duration(moment(meetingReq.end).diff(moment(meetingReq.start), 'minutes'), 'minutes'),
-      bruceOwner,
-      whiteRoom
-    };
-
-    const token = jwtTokenProvider.provideToken(bruceCredentials);
-
-    return request(app).post(`/room/${whiteRoom.email}/meeting`)
-                       .set('Content-Type', 'application/json')
-                       .set('x-access-token', token)
-                       .send(meetingReq)
-                       .expect(200)
-                       .then(() => meetingService.getMeetings(whiteRoom, searchStart, searchEnd))
-                       .then((meetings) => {
-                         meetingService.clearCaches();
-
-                         expect(meetings.length).to.be.at.least(1, 'Expected to find at least one meeting');
-                         const meeting = meetings[0];
-                         return expect(meeting.title).to.be.deep.eq(expected.title);
                        });
   });
 
@@ -195,87 +162,104 @@ describe('meeting routes operations', function testMeetingRoutes() {
                          });
   });
 
+  it('has expected meetings from varying perspectives', function testExpectedNumberOfMeetings() {
+    const searchStart = '2013-02-08 08:00:00';
+    const searchEnd = '2013-02-08 18:00:00';
 
-  it('deletes the meeting', function testDeletingAMeeting() {
-    const meetingStart = '2013-02-08 09:00:00';
-    const meetingEnd = '2013-02-08 09:30:00';
+    const brucesMeetingStart = '2013-02-08 09:00:00';
+    const brucesMeetingEnd = '2013-02-08 09:30:00';
 
-    const momentStart = moment(meetingStart);
-    const momentEnd = moment(meetingEnd);
-    const meetingDuration = moment.duration(30, 'minutes');
+    const brucesMeetingDetails = {
+      title: 'bruces meeting',
+      start: moment(brucesMeetingStart),
+      duration: moment.duration(moment(brucesMeetingEnd).diff(moment(brucesMeetingStart), 'minutes'), 'minutes'),
+      bruceOwner,
+      whiteRoom
+    };
 
-    const searchStart = momentStart.clone().subtract(5, 'minutes');
-    const searchEnd = momentEnd.clone().add(5, 'minutes');
+    const babsMeetingStart = '2013-02-08 09:00:00';
+    const babsMeetingEnd = '2013-02-08 09:30:00';
 
-    return meetingService.createUserMeeting('test delete', momentStart, meetingDuration, bruceOwner, whiteRoom)
-                         .then((meeting: Meeting) => {
-                           logger.info('meeting to delete created!', meeting.id);
-                           const meetingRoom = whiteRoom.email;
-                           const meetingId = meeting.id;
+    const babsMeetingDetails = {
+      title: 'babs meeting',
+      start: moment(babsMeetingStart),
+      duration: moment.duration(moment(babsMeetingEnd).diff(moment(babsMeetingStart), 'minutes'), 'minutes'),
+      babsOwner,
+      redRoom
+    };
 
-                           const token = jwtTokenProvider.provideToken(bruceCredentials);
+    const brucesMeeting = meetingService.createUserMeeting(brucesMeetingDetails.title,
+                                                           brucesMeetingDetails.start,
+                                                           brucesMeetingDetails.duration,
+                                                           brucesMeetingDetails.bruceOwner,
+                                                           brucesMeetingDetails.whiteRoom);
 
-                           return request(app).delete(`/room/${meetingRoom}/meeting/${meetingId}`)
-                                         .set('x-access-token', token)
-                                         .expect(200)
-                                         .then(() => {
-                                           logger.info('delete completed');
-                                            return meeting;
-                                         })
-                                         .catch((e) => {
-                                           throw new Error(`Error deleting meeting ${e}`);
-                                         });
-                         })
-                         .then((meeting) => {
-                           return meetingService.findMeeting(whiteRoom, meeting.id, searchStart, searchEnd).should.eventually.be.rejected;
-                         })
-                         .catch(e => {
-                           return expect.fail(e.message);
-                         });
-  });
+    const babsMeeting = meetingService.createUserMeeting(babsMeetingDetails.title,
+                                                         babsMeetingDetails.start,
+                                                         babsMeetingDetails.duration,
+                                                         babsMeetingDetails.babsOwner,
+                                                         babsMeetingDetails.redRoom);
+
+    const meetingPromises = Promise.all([brucesMeeting, babsMeeting]);
+
+    const bruceToken = jwtTokenProvider.provideToken(bruceCredentials);
+
+    const bruceQuery = meetingPromises.then((meeting) => {
+      return request(app)
+        .get(`/rooms/nyc/meetings?start=${searchStart}&&end=${searchEnd}`)
+        .set('x-access-token', bruceToken)
+        .then(query => {
+          const roomMeetings = query.body as RoomMeetings[];
+          const allMeetings = roomMeetings.reduce((acc, room) => {
+            acc.push.apply(acc, room.meetings);
+            return acc;
+          }, []);
+
+          expect(allMeetings.length).to.be.equal(2);
+
+          const brucesMeetings = allMeetings.filter(m => m.owner.email === bruceOwner.email);
+          const bruceMeeting = brucesMeetings[0];
+          expect(bruceMeeting.title).to.be.equal('bruces meeting');
 
 
-  it('validates parameters against the API properly', function testEndpointValidation() {
-    const validationCases = [
-      {
-        message: 'End date must be after start date',
-        data: {
-          title: 'meeting 0',
-          start: '2013-02-08 09:00:00',
-          end: '2013-02-08 08:00:00',
-        }
-      },
-      {
-        message: 'Title must be provided',
-        data: {
-          title: '',
-          start: '2013-02-08 08:00:00',
-          end: '2013-02-08 09:00:00'
-        }
-      },
-      {
-        message: 'Start date must be provided',
-        data: {
-          title: 'baaad meeting',
-          start: 'baad date',
-          end: '2013-02-08 09:00:00'
-        }
-      },
-    ];
-
-    validationCases.forEach(c => {
-      it(`Create room validations ${c.message}`, () => {
-        const meetingReq: MeetingRequest = c.data;
-
-        return request(app).post('/room/white-room@designit.com@somewhere/meeting')
-                           .set('Content-Type', 'application/json')
-                           .send(meetingReq)
-                           .expect(400)
-                           .then((res) => {
-                             expect(JSON.parse(res.text).message).to.be.eq(c.message);
-                           });
-      });
+          const otherMeetings = allMeetings.filter(m => m.owner.email !== bruceOwner.email);
+          const otherMeeting = otherMeetings[0];
+          expect(otherMeeting.id).to.have.string('obscured');
+          return  expect(otherMeeting.title).to.be.equal('babs');
+        });
     });
+
+    const babsToken = jwtTokenProvider.provideToken(babsCredentials);
+
+    const babsQuery = meetingPromises.then((meeting) => {
+      return request(app)
+        .get(`/rooms/nyc/meetings?start=${searchStart}&&end=${searchEnd}`)
+        .set('x-access-token', babsToken)
+        .then(query => {
+          const roomMeetings = query.body as RoomMeetings[];
+          const allMeetings = roomMeetings.reduce((acc, room) => {
+            acc.push.apply(acc, room.meetings);
+            return acc;
+          }, []);
+
+          expect(allMeetings.length).to.be.equal(2);
+
+          const babsMeetings = allMeetings.filter(m => m.owner.email === babsOwner.email);
+          const babsMeeting = babsMeetings[0];
+          expect(babsMeeting.title).to.be.equal('babs meeting');
+
+          const otherMeetings = allMeetings.filter(m => m.owner.email !== babsOwner.email);
+          const otherMeeting = otherMeetings[0];
+          expect(otherMeeting.id).to.have.string('obscured');
+          return expect(otherMeeting.title).to.be.equal('bruce');
+        });
+    });
+
+    return Promise.all([bruceQuery, babsQuery])
+                  .then(queries => {
+
+                    meetingService.clearCaches();
+                  });
   });
 
 });


### PR DESCRIPTION
Meetings were disappearing on the client due to an unintended "feature" that attempted to hide the meeting id if the user didn't own it.  It was an attempt at another layer of security to prevent updating of meetings.  However, this broke the client since it (and React) required the meeting id as the key.  This change now provides an id but one that has no bearing on any id that Microsoft would be aware of or would have provided. 