### PR TITLE
Respond with valid JSON when user service errors

### DIFF
--- a/src/rest/user_routes.ts
+++ b/src/rest/user_routes.ts
@@ -20,7 +20,8 @@ export function configureUsersRoutes(app: Express,
         res.json(users);
       })
       .catch(err => {
-        res.send(err);
+        logger.error(err);
+        res.send([]);
       });
   });
 


### PR DESCRIPTION
Currently, we are passing any errors with the user service back to the
client. This breaks the client because the client is expecting valid
JSON.

This commit sends an empty array when the user service throws an error.
It logs the error on the server side, but does not expose the error to
the client.